### PR TITLE
Improve detection of Envoy-S with consumption metering

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -28,7 +28,7 @@ class EnvoyReader():
         self.endpoint_url = "http://{}/production.json".format(self.host)
         response = await requests.get(
             self.endpoint_url, timeout=30, allow_redirects=False)
-        if response.status_code == 200 and len(response.json()) == 3:
+        if response.status_code == 200 and len(response.json()) >= 2:
             self.endpoint_type = "PC"
             return
 


### PR DESCRIPTION
This small tweak fixes the check of the json length , which was causing a false negative on the detection of my Envoy-S with consumption metering. My Envoy-S returns two top sections, one for production and one for consumption.

```
$ curl -s http://envoy/production.json | jq length
2
```
This manifested as envoy_reader failing to pull my consumption data ("Consumption data not available for your Envoy device.") and was less transparent as it was reported in Home Assistant ("Unable to connect to Envoy. Check that the device is up at 'http://envoy'.").

I left it as a >=2 check since I'm unsure if other Envoy-S hardware revisions have different output. Has someone else confirmed they have a json response with 3 sections?

