### PR TITLE
support older Envoy C with only .html, no .json

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Also reads production from individual inverters if supported.
 Tested on the original Envoy (production data only) and the Envoy S (production and consumption data).
 
 This reader uses a JSON endpoint on the Envoy gateway:
-
-- Original Envoy: http://envoy/api/v1/production
+- Original Envoy: http://envoy/api/v1/production    (available on software level R3.9 and later)
 - Envoy S: http://envoy/production.json
+
+For older Envoy with software before R3.9, data is collected from html at http://envoy/production

--- a/envoy_reader/__init__.py
+++ b/envoy_reader/__init__.py
@@ -1,1 +1,0 @@
-from envoy_reader.envoy_reader import EnvoyReader

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -4,13 +4,24 @@ import asyncio
 import sys
 import json
 from requests.auth import HTTPDigestAuth
-import requests as requests_sync
-import requests_async as requests
+import requests
+#import requests as requests_sync
+#import requests_async as requests
+import re
 
+PRODUCTION_REGEX = \
+    r'<td>Currentl.*</td>\s+<td>\s*(\d+|\d+\.\d+)\s*(W|kW|MW)</td>'
+DAY_PRODUCTION_REGEX = \
+    r'<td>Today</td>\s+<td>\s*(\d+|\d+\.\d+)\s*(Wh|kWh|MWh)</td>'
+WEEK_PRODUCTION_REGEX = \
+    r'<td>Past Week</td>\s+<td>\s*(\d+|\d+\.\d+)\s*(Wh|kWh|MWh)</td>'
+LIFE_PRODUCTION_REGEX = \
+    r'<td>Since Installation</td>\s+<td>\s*(\d+|\d+\.\d+)\s*(Wh|kWh|MWh)</td>'
 
 class EnvoyReader():
     """Instance of EnvoyReader"""
-    # P for production data only (ie. Envoy model C)
+    # P0 for older Envoy model C, s/w < R3.9 no json pages
+    # P for production data only (ie. Envoy model C, s/w >= R3.9)
     # PC for production and consumption data (ie. Envoy model S)
 
     message_consumption_not_available = ("Consumption data not available for "
@@ -22,27 +33,34 @@ class EnvoyReader():
         self.endpoint_url = ""
         self.serial_number_last_six = ""
 
-    async def detect_model(self):
+    def detect_model(self):
         """Method to determine if the Envoy supports consumption values or
          only production"""
         self.endpoint_url = "http://{}/production.json".format(self.host)
-        response = await requests.get(
-            self.endpoint_url, timeout=30, allow_redirects=False)
-        if response.status_code == 200 and len(response.json()) == 3:
-            self.endpoint_type = "PC"
-            return
-
-        self.endpoint_url = "http://{}/api/v1/production".format(self.host)
         response = requests.get(
             self.endpoint_url, timeout=30, allow_redirects=False)
-        if response.status_code == 200:
-            self.endpoint_type = "P"
+        if response.status_code == 200 and len(response.json()) == 3:
+            self.endpoint_type = "PC"       # Envoy-S with consumption
             return
+        else:
+            self.endpoint_url = "http://{}/api/v1/production".format(self.host)
+            response = requests.get(
+                self.endpoint_url, timeout=30, allow_redirects=False)
+            if response.status_code == 200:
+                self.endpoint_type = "P"       # Envoy-C, production only
+                return
+            else:
+                self.endpoint_url = "http://{}/production".format(self.host)
+                response = requests.get(
+                    self.endpoint_url, timeout=30, allow_redirects=False)
+                if response.status_code == 200:
+                    self.endpoint_type = "P0"       # older Envoy-C
+                    return
 
         self.endpoint_url = ""
         raise RuntimeError(
-            "Could not connect or determine Envoy model. " +
-            "Check that the device is up at 'http://" + self.host + "'.")
+                "Could not connect or determine Envoy model. " +
+                "Check that the device is up at 'http://" + self.host + "'.")
 
     async def get_serial_number(self):
         """Method to get last six digits of Envoy serial number for auth"""
@@ -59,156 +77,243 @@ class EnvoyReader():
         #         "Unable to find device serial number, " +
         #         "this is needed to read inverter production.")
 
-    async def call_api(self):
+    def call_api(self):
         """Method to call the Envoy API"""
-        # detection of endpoint
+        # detection of endpoint if not already known
         if self.endpoint_type == "":
-            await self.detect_model()
+            self.detect_model()
 
-        response = await requests.get(
+        response = requests.get(
             self.endpoint_url, timeout=30, allow_redirects=False)
-        return response.json()
+        if self.endpoint_type == "P" or self.endpoint_type == "PC":
+            return response.json()     # these Envoys have .json
+        if self.endpoint_type == "P0":
+            return response.text       # these Envoys have .html
 
     def create_connect_errormessage(self):
         """Create error message if unable to connect to Envoy"""
         return ("Unable to connect to Envoy. " +
-                "Check that the device is up at 'http://"
+                "Check that the device is up at 'http://" 
                 + self.host + "'.")
 
     def create_json_errormessage(self):
         """Create error message if unable to parse JSON response"""
-        return ("Got a response from '" + self.endpoint_url +
+        return ("Got a response from '" + self.endpoint_url + 
                 "', but metric could not be found. " +
                 "Maybe your model of Envoy doesn't " +
                 "support the requested metric.")
 
-    async def production(self):
+    def production(self):
         """Call API and parse production values from response"""
+        if self.endpoint_type == "":
+            EnvoyReader.detect_model(self)
+
         try:
-            raw_json = await self.call_api()
             if self.endpoint_type == "PC":
+                raw_json = EnvoyReader.call_api(self)
                 production = raw_json["production"][1]["wNow"]
             else:
-                production = raw_json["wattsNow"]
+                if self.endpoint_type == "P":
+                    raw_json = EnvoyReader.call_api(self)
+                    production = raw_json["wattsNow"]
+                else:
+                    if self.endpoint_type == "P0":
+                        text = EnvoyReader.call_api(self)
+                        match = re.search(
+                            PRODUCTION_REGEX, text, re.MULTILINE)
+                        if match:
+                            if match.group(2) == "kW":
+                                production = float(match.group(1))*1000
+                            else:
+                                if match.group(2) == "mW":
+                                    production = float(
+                                        match.group(1))*1000000
+                                else:
+                                    production = float(match.group(1))
+                        else:
+                            raise RuntimeError(
+                                "No match for production, check REGEX  "
+                                +  text)
             return int(production)
 
         except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
+            return EnvoyReader.create_connect_errormessage(self)
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
+            return EnvoyReader.create_json_errormessage(self)
 
-    async def consumption(self):
+    def consumption(self):
         """Call API and parse consumption values from response"""
-        if self.endpoint_type == "P":
+        if self.endpoint_type == "P" or self.endpoint_type == "P0":
             return self.message_consumption_not_available
 
         try:
-            raw_json = await self.call_api()
+            raw_json = EnvoyReader.call_api(self)
             consumption = raw_json["consumption"][0]["wNow"]
             return int(consumption)
 
         except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
+            return EnvoyReader.create_connect_errormessage(self)
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
+            return EnvoyReader.create_json_errormessage(self)
 
-    async def daily_production(self):
+    def daily_production(self):
         """Call API and parse todays production values from response"""
+        if self.endpoint_type == "":
+            EnvoyReader.detect_model(self)
+
         try:
-            raw_json = await self.call_api()
             if self.endpoint_type == "PC":
+                raw_json = EnvoyReader.call_api(self)
                 daily_production = raw_json["production"][1]["whToday"]
             else:
-                daily_production = raw_json["wattHoursToday"]
+                if self.endpoint_type == "P":
+                    raw_json = EnvoyReader.call_api(self)
+                    daily_production = raw_json["wattHoursToday"]
+                else:
+                    if self.endpoint_type == "P0":
+                        text = EnvoyReader.call_api(self)
+                        match = re.search(
+                            DAY_PRODUCTION_REGEX, text, re.MULTILINE)
+                        if match:
+                            if match.group(2) == "kWh":
+                                daily_production = float(
+                                    match.group(1))*1000
+                            else:
+                                if match.group(2) == "MWh":
+                                    daily_production = float(
+                                        match.group(1))*1000000
+                                else:
+                                    daily_production = float(
+                                        match.group(1))
+                        else:
+                            raise RuntimeError(
+                                "No match for Day production, "
+                                "check REGEX  " +
+                                text)
             return int(daily_production)
 
         except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
+            return EnvoyReader.create_connect_errormessage(self)
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
+            return EnvoyReader.create_json_errormessage(self)
 
-    async def daily_consumption(self):
+    def daily_consumption(self):
         """Call API and parse todays consumption values from response"""
-        if self.endpoint_type == "P":
+        if self.endpoint_type == "P" or self.endpoint_type == "P0":
             return self.message_consumption_not_available
 
         try:
-            raw_json = await self.call_api()
+            raw_json = EnvoyReader.call_api(self)
             daily_consumption = raw_json["consumption"][0]["whToday"]
             return int(daily_consumption)
 
         except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
+            return EnvoyReader.create_connect_errormessage(self)
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
+            return EnvoyReader.create_json_errormessage(self)
 
-    async def seven_days_production(self):
+    def seven_days_production(self):
         """Call API and parse the past seven days production values from the
          response"""
+        if self.endpoint_type == "":
+            EnvoyReader.detect_model(self)
+
         try:
-            raw_json = await self.call_api()
             if self.endpoint_type == "PC":
+                raw_json = EnvoyReader.call_api(self)
                 seven_days_production = raw_json["production"][1]["whLastSevenDays"]
             else:
-                seven_days_production = raw_json["wattHoursSevenDays"]
+                if self.endpoint_type == "P":
+                    raw_json = EnvoyReader.call_api(self)
+                    seven_days_production = raw_json["wattHoursSevenDays"]
+                else:
+                    if self.endpoint_type == "P0":
+                        text = EnvoyReader.call_api(self)
+                        match = re.search(
+                            WEEK_PRODUCTION_REGEX, text, re.MULTILINE)
+                        if match:
+                            if match.group(2) == "kWh":
+                                seven_days_production = float(
+                                    match.group(1))*1000
+                            else:
+                                if match.group(2) == "MWh":
+                                    seven_days_production = float(
+                                        match.group(1))*1000000
+                                else:
+                                    seven_days_production = float(
+                                        match.group(1))
+                        else:
+                            raise RuntimeError("No match for 7 Day production, "
+                                "check REGEX " +  text)
             return int(seven_days_production)
 
         except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
+            return EnvoyReader.create_connect_errormessage(self)
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
+            return EnvoyReader.create_json_errormessage(self)
 
-    async def seven_days_consumption(self):
+    def seven_days_consumption(self):
         """Call API and parse the past seven days consumption values from
          the response"""
-        if self.endpoint_type == "P":
+        if self.endpoint_type == "P" or self.endpoint_type == "P0":
             return self.message_consumption_not_available
 
         try:
-            raw_json = await self.call_api()
+            raw_json = EnvoyReader.call_api(self)
             seven_days_consumption = raw_json["consumption"][0]["whLastSevenDays"]
             return int(seven_days_consumption)
 
         except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
+            return EnvoyReader.create_connect_errormessage(self)
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
+            return EnvoyReader.create_json_errormessage(self)
 
-    async def lifetime_production(self):
+    def lifetime_production(self):
         """Call API and parse the lifetime of production from response"""
+        if self.endpoint_type == "":
+            EnvoyReader.detect_model(self)
+
         try:
-            raw_json = await self.call_api()
             if self.endpoint_type == "PC":
+                raw_json = EnvoyReader.call_api(self)
                 lifetime_production = raw_json["production"][1]["whLifetime"]
             else:
-                lifetime_production = raw_json["wattHoursLifetime"]
+                if self.endpoint_type == "P":
+                    raw_json = EnvoyReader.call_api(self)
+                    lifetime_production = raw_json["wattHoursLifetime"]
+                else:
+                    if self.endpoint_type == "P0":
+                        text = EnvoyReader.call_api(self)
+                        match = re.search(
+                            LIFE_PRODUCTION_REGEX, text, re.MULTILINE)
+                        if match:
+                            if match.group(2) == "kWh":
+                                lifetime_production = float(
+                                    match.group(1))*1000
+                            else:
+                                if match.group(2) == "MWh":
+                                    lifetime_production = float(
+                                        match.group(1))*1000000
+                                else:
+                                    lifetime_production = float(
+                                        match.group(1))
+                        else:
+                            raise RuntimeError(
+                                "No match for Lifetime production, "
+                                "check REGEX " +  text)
             return int(lifetime_production)
 
         except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
+            return EnvoyReader.create_connect_errormessage(self)
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
+            return EnvoyReader.create_json_errormessage(self)
 
-    async def lifetime_consumption(self):
-        """Call API and parse the lifetime of consumption from response"""
-        if self.endpoint_type == "P":
-            return self.message_consumption_not_available
-
-        try:
-            raw_json = await self.call_api()
-            lifetime_consumption = raw_json["consumption"][0]["whLifetime"]
-            return int(lifetime_consumption)
-
-        except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
-        except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return self.create_json_errormessage()
-
-    async def inverters_production(self):
+    def inverters_production(self):
         """Hit a different Envoy endpoint and get the production values for
          individual inverters"""
         if self.serial_number_last_six == "":
-            await self.get_serial_number()
+#            await self.get_serial_number()
+            self.get_serial_number()
         try:
             response = requests_sync.get(
                 "http://{}/api/v1/production/inverters"
@@ -223,6 +328,21 @@ class EnvoyReader():
             return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError, TypeError):
             return self.create_json_errormessage()
+
+    def lifetime_consumption(self):
+        """Call API and parse the lifetime of consumption from response"""
+        if self.endpoint_type == "P" or self.endpoint_type == "P0":
+            return self.message_consumption_not_available
+
+        try:
+            raw_json = EnvoyReader.call_api(self)
+            lifetime_consumption = raw_json["consumption"][0]["whLifetime"]
+            return int(lifetime_consumption)
+
+        except requests.exceptions.ConnectionError:
+            return EnvoyReader.create_connect_errormessage(self)
+        except (json.decoder.JSONDecodeError, KeyError, IndexError):
+            return EnvoyReader.create_json_errormessage(self)
 
     def run_in_console(self):
         """If running this module directly, print all the values in the
@@ -248,7 +368,8 @@ class EnvoyReader():
         print("seven_days_consumption:  {}".format(results[5]))
         print("lifetime_production:     {}".format(results[6]))
         print("lifetime_consumption:    {}".format(results[7]))
-        print("inverters_production:   {}".format(results[8]))
+        print("inverters_production:    {}".format(results[8]))
+
 
 
 if __name__ == "__main__":

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -368,7 +368,7 @@ class EnvoyReader():
         print("seven_days_consumption:  {}".format(results[5]))
         print("lifetime_production:     {}".format(results[6]))
         print("lifetime_consumption:    {}".format(results[7]))
-        print("inverters_production:    {}".format(results[8]))
+        print("inverters_production:   {}".format(results[8]))
 
 
 

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -59,8 +59,8 @@ class EnvoyReader():
 
         self.endpoint_url = ""
         raise RuntimeError(
-                "Could not connect or determine Envoy model. " +
-                "Check that the device is up at 'http://" + self.host + "'.")
+            "Could not connect or determine Envoy model. " +
+            "Check that the device is up at 'http://" + self.host + "'.")
 
     async def get_serial_number(self):
         """Method to get last six digits of Envoy serial number for auth"""
@@ -93,12 +93,12 @@ class EnvoyReader():
     def create_connect_errormessage(self):
         """Create error message if unable to connect to Envoy"""
         return ("Unable to connect to Envoy. " +
-                "Check that the device is up at 'http://" 
+                "Check that the device is up at 'http://"
                 + self.host + "'.")
 
     def create_json_errormessage(self):
         """Create error message if unable to parse JSON response"""
-        return ("Got a response from '" + self.endpoint_url + 
+        return ("Got a response from '" + self.endpoint_url +
                 "', but metric could not be found. " +
                 "Maybe your model of Envoy doesn't " +
                 "support the requested metric.")
@@ -137,9 +137,9 @@ class EnvoyReader():
             return int(production)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def consumption(self):
         """Call API and parse consumption values from response"""
@@ -152,26 +152,26 @@ class EnvoyReader():
             return int(consumption)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def daily_production(self):
         """Call API and parse todays production values from response"""
         if self.endpoint_type == "":
-            EnvoyReader.detect_model(self)
+            self.detect_model()
 
         try:
             if self.endpoint_type == "PC":
-                raw_json = EnvoyReader.call_api(self)
+                raw_json = self.call_api()
                 daily_production = raw_json["production"][1]["whToday"]
             else:
                 if self.endpoint_type == "P":
-                    raw_json = EnvoyReader.call_api(self)
+                    raw_json = self.call_api()
                     daily_production = raw_json["wattHoursToday"]
                 else:
                     if self.endpoint_type == "P0":
-                        text = EnvoyReader.call_api(self)
+                        text = self.call_api()
                         match = re.search(
                             DAY_PRODUCTION_REGEX, text, re.MULTILINE)
                         if match:
@@ -193,9 +193,9 @@ class EnvoyReader():
             return int(daily_production)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def daily_consumption(self):
         """Call API and parse todays consumption values from response"""
@@ -203,32 +203,32 @@ class EnvoyReader():
             return self.message_consumption_not_available
 
         try:
-            raw_json = EnvoyReader.call_api(self)
+            raw_json = self.call_api()
             daily_consumption = raw_json["consumption"][0]["whToday"]
             return int(daily_consumption)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def seven_days_production(self):
         """Call API and parse the past seven days production values from the
          response"""
         if self.endpoint_type == "":
-            EnvoyReader.detect_model(self)
+            self.detect_model()
 
         try:
             if self.endpoint_type == "PC":
-                raw_json = EnvoyReader.call_api(self)
+                raw_json = self.call_api()
                 seven_days_production = raw_json["production"][1]["whLastSevenDays"]
             else:
                 if self.endpoint_type == "P":
-                    raw_json = EnvoyReader.call_api(self)
+                    raw_json = self.call_api()
                     seven_days_production = raw_json["wattHoursSevenDays"]
                 else:
                     if self.endpoint_type == "P0":
-                        text = EnvoyReader.call_api(self)
+                        text = self.call_api()
                         match = re.search(
                             WEEK_PRODUCTION_REGEX, text, re.MULTILINE)
                         if match:
@@ -248,9 +248,9 @@ class EnvoyReader():
             return int(seven_days_production)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def seven_days_consumption(self):
         """Call API and parse the past seven days consumption values from
@@ -259,31 +259,31 @@ class EnvoyReader():
             return self.message_consumption_not_available
 
         try:
-            raw_json = EnvoyReader.call_api(self)
+            raw_json = self.call_api()
             seven_days_consumption = raw_json["consumption"][0]["whLastSevenDays"]
             return int(seven_days_consumption)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def lifetime_production(self):
         """Call API and parse the lifetime of production from response"""
         if self.endpoint_type == "":
-            EnvoyReader.detect_model(self)
+            self.detect_model()
 
         try:
             if self.endpoint_type == "PC":
-                raw_json = EnvoyReader.call_api(self)
+                raw_json = self.call_api()
                 lifetime_production = raw_json["production"][1]["whLifetime"]
             else:
                 if self.endpoint_type == "P":
-                    raw_json = EnvoyReader.call_api(self)
+                    raw_json = self.call_api()
                     lifetime_production = raw_json["wattHoursLifetime"]
                 else:
                     if self.endpoint_type == "P0":
-                        text = EnvoyReader.call_api(self)
+                        text = self.call_api()
                         match = re.search(
                             LIFE_PRODUCTION_REGEX, text, re.MULTILINE)
                         if match:
@@ -304,9 +304,9 @@ class EnvoyReader():
             return int(lifetime_production)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def inverters_production(self):
         """Hit a different Envoy endpoint and get the production values for
@@ -340,9 +340,9 @@ class EnvoyReader():
             return int(lifetime_consumption)
 
         except requests.exceptions.ConnectionError:
-            return EnvoyReader.create_connect_errormessage(self)
+            return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
-            return EnvoyReader.create_json_errormessage(self)
+            return self.create_json_errormessage()
 
     def run_in_console(self):
         """If running this module directly, print all the values in the

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -67,8 +67,9 @@ class EnvoyReader():
             response = await requests.get(
                 "http://{}/info.xml".format(self.host),
                 timeout=10, allow_redirects=False)
-            sn = response.text.split("<sn>")[1].split("</sn>")[0][-6:]
-            self.serial_number_last_six = sn
+            if len(response.text) > 0:
+                sn = response.text.split("<sn>")[1].split("</sn>")[0][-6:]
+                self.serial_number_last_six = sn
         except requests.exceptions.ConnectionError:
             return self.create_connect_errormessage()
         # except

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -4,7 +4,6 @@ import asyncio
 import sys
 import json
 from requests.auth import HTTPDigestAuth
-#import requests
 import requests as requests_sync
 import requests_async as requests
 import re
@@ -308,6 +307,21 @@ class EnvoyReader():
         except (json.decoder.JSONDecodeError, KeyError, IndexError):
             return self.create_json_errormessage()
 
+    async def lifetime_consumption(self):
+        """Call API and parse the lifetime of consumption from response"""
+        if self.endpoint_type == "P" or self.endpoint_type == "P0":
+            return self.message_consumption_not_available
+
+        try:
+            raw_json = await self.call_api()
+            lifetime_consumption = raw_json["consumption"][0]["whLifetime"]
+            return int(lifetime_consumption)
+
+        except requests.exceptions.ConnectionError:
+            return self.create_connect_errormessage()
+        except (json.decoder.JSONDecodeError, KeyError, IndexError):
+            return self.create_json_errormessage()
+
     async def inverters_production(self):
         """Hit a different Envoy endpoint and get the production values for
          individual inverters"""
@@ -326,21 +340,6 @@ class EnvoyReader():
         except requests.exceptions.ConnectionError:
             return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError, TypeError):
-            return self.create_json_errormessage()
-
-    def lifetime_consumption(self):
-        """Call API and parse the lifetime of consumption from response"""
-        if self.endpoint_type == "P" or self.endpoint_type == "P0":
-            return self.message_consumption_not_available
-
-        try:
-            raw_json = EnvoyReader.call_api(self)
-            lifetime_consumption = raw_json["consumption"][0]["whLifetime"]
-            return int(lifetime_consumption)
-
-        except requests.exceptions.ConnectionError:
-            return self.create_connect_errormessage()
-        except (json.decoder.JSONDecodeError, KeyError, IndexError):
             return self.create_json_errormessage()
 
     def run_in_console(self):
@@ -368,7 +367,6 @@ class EnvoyReader():
         print("lifetime_production:     {}".format(results[6]))
         print("lifetime_consumption:    {}".format(results[7]))
         print("inverters_production:   {}".format(results[8]))
-
 
 
 if __name__ == "__main__":

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -106,7 +106,7 @@ class EnvoyReader():
     async def production(self):
         """Call API and parse production values from response"""
         if self.endpoint_type == "":
-            EnvoyReader.detect_model(self)
+            await self.detect_model()
 
         try:
             if self.endpoint_type == "PC":
@@ -159,7 +159,7 @@ class EnvoyReader():
     async def daily_production(self):
         """Call API and parse todays production values from response"""
         if self.endpoint_type == "":
-            self.detect_model()
+            await self.detect_model()
 
         try:
             if self.endpoint_type == "PC":
@@ -216,7 +216,7 @@ class EnvoyReader():
         """Call API and parse the past seven days production values from the
          response"""
         if self.endpoint_type == "":
-            self.detect_model()
+            await self.detect_model()
 
         try:
             if self.endpoint_type == "PC":
@@ -271,7 +271,7 @@ class EnvoyReader():
     async def lifetime_production(self):
         """Call API and parse the lifetime of production from response"""
         if self.endpoint_type == "":
-            self.detect_model()
+            await self.detect_model()
 
         try:
             if self.endpoint_type == "PC":


### PR DESCRIPTION
older Envoys (mine....) with software before R3.9, do not have the .json data available, only .html pages, http://envoy/production is the main one.    added code to detect this older version of Envoy and scrape the html.

my envoy_reader.py doesn't use the recently added await commands, I couldn't get requests_async working.  But otherwise it works on my system now, and I believe it shouldn't break any of the .json based data collection for newer Envoys.

also updated the README.md file

please let me know if anything else I should do or fix,   Thanks,   Dale