### PR TITLE
Fix support for Envoy 'P' models that do not have consumption capabilities

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -145,6 +145,8 @@ class EnvoyReader():
 
     async def consumption(self):
         """Call API and parse consumption values from response"""
+        if self.endpoint_type == "":
+            await self.detect_model()
         if self.endpoint_type == "P" or self.endpoint_type == "P0":
             return self.message_consumption_not_available
 
@@ -201,6 +203,8 @@ class EnvoyReader():
 
     async def daily_consumption(self):
         """Call API and parse todays consumption values from response"""
+        if self.endpoint_type == "":
+            await self.detect_model()
         if self.endpoint_type == "P" or self.endpoint_type == "P0":
             return self.message_consumption_not_available
 
@@ -257,6 +261,8 @@ class EnvoyReader():
     async def seven_days_consumption(self):
         """Call API and parse the past seven days consumption values from
          the response"""
+        if self.endpoint_type == "":
+            await self.detect_model()
         if self.endpoint_type == "P" or self.endpoint_type == "P0":
             return self.message_consumption_not_available
 
@@ -312,6 +318,8 @@ class EnvoyReader():
 
     async def lifetime_consumption(self):
         """Call API and parse the lifetime of consumption from response"""
+        if self.endpoint_type == "":
+            await self.detect_model()
         if self.endpoint_type == "P" or self.endpoint_type == "P0":
             return self.message_consumption_not_available
 


### PR DESCRIPTION
Due to the asynchronous nature of this code, whenever a consumption call is made, and the model is not yet known from a 'production' call, the `message_consumption_not_available` is not returned, because the model is still an empty string.

This is in the case where the Envoy model does not support 'consumption'.

This merge request should fix these cases by also doing a model detection on the consumption calls.

I'll link an issue I am drafting from another project that is using this library as a plugin with a more detailed report.

Let me know what you think :)