### PR TITLE
Raise an exception when Authentication fails for Inverter data

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -354,11 +354,14 @@ class EnvoyReader():
                 .format(self.host),
                 auth=HTTPDigestAuth(self.username,
                                     self.password))
-            response_dict = {}
-            for item in response.json():
-                response_dict[item["serialNumber"]] = [item["lastReportWatts"],
-                                                       time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item["lastReportDate"]))]
-            return response_dict
+            if response is not None and response.status_code != 401:                                    
+                response_dict = {}
+                for item in response.json():
+                    response_dict[item["serialNumber"]] = [item["lastReportWatts"],
+                                                        time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item["lastReportDate"]))]
+                return response_dict
+            else:
+                raise Exception(f'Authentication failed for Enphase Envoy: {self.host}')
         except requests.exceptions.ConnectionError:
             return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError, TypeError):

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -361,7 +361,7 @@ class EnvoyReader():
                                                         time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item["lastReportDate"]))]
                 return response_dict
             else:
-                raise Exception(f'Authentication failed for Enphase Envoy: {self.host}')
+                response.raise_for_status()
         except requests.exceptions.ConnectionError:
             return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError, TypeError):


### PR DESCRIPTION
The Envoy API was printing out a message to the console when inverter data was unable to be collected.  For Home Assistant to consume and log the error in its own log, I raised an exception instead.

There are other cases where the error messages being printed to the console will not be displayed in the HA logs.  But given my lack of knowledge with exceptions, I didn't want to change too much code! :grin:

This change is for the HA PR [#28837](https://github.com/home-assistant/home-assistant/pull/28837)