### PR TITLE
Use better detection for PC type

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -37,13 +37,17 @@ class EnvoyReader():
         self.endpoint_url = ""
         self.serial_number_last_six = ""
 
+    def hasProductionAndConsumption(self, json):
+        """Check if json has keys for both production and consumption"""
+        return "production" in json and "consumption" in json
+
     async def detect_model(self):
         """Method to determine if the Envoy supports consumption values or
          only production"""
         self.endpoint_url = "http://{}/production.json".format(self.host)
         response = await requests.get(
             self.endpoint_url, timeout=30, allow_redirects=False)
-        if response.status_code == 200 and len(response.json()) >= 2:
+        if response.status_code == 200 and self.hasProductionAndConsumption(response.json()):
             self.endpoint_type = "PC"
             return
         else:


### PR DESCRIPTION
This PR should improve the model detection of different types.

Currently the type I test with is a P-type, which has the following production.json:

```
{
   "production" : [
      {
         "activeCount" : 12,
         "readingTime" : 12345678,
         "type" : "inverters",
         "whLifetime" : 12345678,
         "wNow" : 123
      }
   ],
   "storage" : [
      {
         "activeCount" : 0,
         "type" : "acb",
         "readingTime" : 0,
         "state" : "idle",
         "whNow" : 0,
         "wNow" : 0
      }
   ]
}
```

The device I am testing with is not my own, and thus I don't always have access to it.
I am trying to fix homeassistant integration with this, and after using this patch and the previous PR, the values show up in HA.

Would be nice if somebody with a PC-type could test that this patch doesn't break anything.