### PR TITLE
Add a single entry point for Home Assistant

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -367,6 +367,31 @@ class EnvoyReader():
         except (json.decoder.JSONDecodeError, KeyError, IndexError, TypeError):
             return self.create_json_errormessage()
 
+    async def update(self):
+        """
+        Single entry point for Home Assistant
+        """
+        data = {}
+
+        tasks = [
+            self.production(),
+            self.consumption(),
+            self.daily_production(),
+            self.daily_consumption(),
+            self.seven_days_production(),
+            self.seven_days_consumption(),
+            self.lifetime_production(),
+            self.lifetime_consumption(),
+            self.inverters_production()
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for key, result in zip(tasks, results):
+            key = key.__name__
+            data[key] = result
+
+        return data
+
     def run_in_console(self):
         """If running this module directly, print all the values in the
          console."""


### PR DESCRIPTION
Add in a single method that Home Assistant will use to grab data once every time it polls.

This is not a complete fix, but a beginning to reduce the number of calls being made to Envoys.  Using this method and an updated HA sensor code the Envoy running firmware >= 3.9 is not overwhelmed which previously caused the Envoy to not respond sometimes when requesting inverter data.