### PR TITLE
Replace sync inverter call with async

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -3,7 +3,6 @@ import json
 import time
 
 from requests.auth import HTTPDigestAuth
-import requests as requests_sync
 import requests_async as requests
 import re
 import httpx

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import time
 
-from requests.auth import HTTPDigestAuth
 import requests_async as requests
 import re
 import httpx

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -375,7 +375,7 @@ class EnvoyReader():
                 return response_dict
             else:
                 response.raise_for_status()
-        except httpx.exceptions.HTTPError:
+        except httpx.HTTPError:
             return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError, TypeError):
             return self.create_json_errormessage()

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -362,11 +362,6 @@ class EnvoyReader():
                 response = await client.get("http://{}/api/v1/production/inverters"
                                             .format(self.host),
                                             auth=httpx.DigestAuth(self.username, self.password))
-            #response = requests_sync.get(
-            #    "http://{}/api/v1/production/inverters"
-            #    .format(self.host),
-            #    auth=HTTPDigestAuth(self.username,
-            #                        self.password))
             if response is not None and response.status_code != 401:                                    
                 response_dict = {}
                 for item in response.json():

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -6,6 +6,8 @@ from requests.auth import HTTPDigestAuth
 import requests as requests_sync
 import requests_async as requests
 import re
+import httpx
+import h11
 
 """Module to read production and consumption values from an Enphase Envoy on
  the local network"""
@@ -356,11 +358,15 @@ class EnvoyReader():
                 self.password = self.serial_number_last_six
 
         try:
-            response = requests_sync.get(
-                "http://{}/api/v1/production/inverters"
-                .format(self.host),
-                auth=HTTPDigestAuth(self.username,
-                                    self.password))
+            async with httpx.AsyncClient() as client:
+                response = await client.get("http://{}/api/v1/production/inverters"
+                                            .format(self.host),
+                                            auth=httpx.DigestAuth(self.username, self.password))
+            #response = requests_sync.get(
+            #    "http://{}/api/v1/production/inverters"
+            #    .format(self.host),
+            #    auth=HTTPDigestAuth(self.username,
+            #                        self.password))
             if response is not None and response.status_code != 401:                                    
                 response_dict = {}
                 for item in response.json():
@@ -369,10 +375,12 @@ class EnvoyReader():
                 return response_dict
             else:
                 response.raise_for_status()
-        except requests.exceptions.ConnectionError:
+        except httpx.exceptions.HTTPError:
             return self.create_connect_errormessage()
         except (json.decoder.JSONDecodeError, KeyError, IndexError, TypeError):
             return self.create_json_errormessage()
+        except h11.RemoteProtocolError:
+            await response.close()
 
     async def update(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests_async >= 0.6.0
+httpx >= 0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests >= 2.22.0
 requests_async >= 0.6.0


### PR DESCRIPTION
Home Assistant 0.109 is now checking if I/O is occurring within the event loop and then logging a Warning message.  This message is occurring with the envoy sensor due to the [requests_sync call](https://github.com/jesserizzo/envoy_reader/blob/ee176190ebe95d98d6414deecf6d710438270cf9/envoy_reader/envoy_reader.py#L359) that is called from an async HA call

I was unable to get the currently used `requests_async` library or the preferred HTTP library of `aiohttp` to work with HTTP Digest Authentication.  So I changed the `inverters_production()` method to use the `httpx` library

Fixes #28 