### PR TITLE
Increase HTTP timeout for inverter production call

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -358,7 +358,7 @@ class EnvoyReader():
         try:
             async with httpx.AsyncClient() as client:
                 response = await client.get("http://{}/api/v1/production/inverters"
-                                            .format(self.host),
+                                            .format(self.host), timeout=30,
                                             auth=httpx.DigestAuth(self.username, self.password))
             if response is not None and response.status_code != 401:                                    
                 response_dict = {}


### PR DESCRIPTION
Increased timeout from default of 5secs to 30secs

Fixes #34 