### PR TITLE
Retrieve Production data based on CT (eim) count

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -422,10 +422,7 @@ class EnvoyReader():
         """
         data = {}
 
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(asyncio.gather(
-            self.getData()
-        ))
+        await self.getData()
         
         tasks = [
             self.production(),

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -464,7 +464,6 @@ class EnvoyReader():
             self.lifetime_consumption(),
             self.inverters_production()))
 
-        print("Metering (CT) Status:    {}".format(self.isMeteringEnabled))
         print("production:              {}".format(results[0]))
         print("consumption:             {}".format(results[1]))
         print("daily_production:        {}".format(results[2]))

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -139,9 +139,9 @@ class EnvoyReader():
             if self.endpoint_type == "PC":
                 raw_json = self.endpoint_production_json_results.json()
                 if self.isMeteringEnabled:
-                    production = raw_json["production"][0]["wNow"]
-                else:
                     production = raw_json["production"][1]["wNow"]
+                else:
+                    production = raw_json["production"][0]["wNow"]
             else:
                 if self.endpoint_type == "P":
                     raw_json = self.endpoint_production_v1_results.json()
@@ -467,6 +467,7 @@ class EnvoyReader():
             self.lifetime_consumption(),
             self.inverters_production()))
 
+        print("Metering (CT) Status:    {}".format(self.isMeteringEnabled))
         print("production:              {}".format(results[0]))
         print("consumption:             {}".format(results[1]))
         print("daily_production:        {}".format(results[2]))


### PR DESCRIPTION
Issue #37 mentioned that data is not correct when Metering on an Envoy S/IQ Envoy is not enabled.

Looking at the code the ["production"][1]["wNow"] is retrieved from the /production.json page. This section of the json page is used for the Production value for a CT that is installed to read the production from the solar array.  In some cases the Envoy uses ["production"][1]["wNow"] AND ["production"][0]["wNow"] when metering is not enabled.  Not sure if this is in the Envoy firmware or if the user has CTs installed and the firmware reads the sensor but has not enabled/setup metering.

In any case to fix the problem that Issue #37 has the code has changed to look at the ["production"][1]["activeCount"] value. If the value is 0 than this says Metering is not enabled on the Envoy and the current wH value and Lifetime watt value will be retrieved from ["production"][0]["wNow"] and ["production"][0]["whLifetime"], respectively, with the other production values coming from the /api/v1/production page.

If the ["production"][1]["activeCount"]  value is greater than 0 than Metering is enabled and all Production values will come from their respective section of ["production"][1]

The PR also includes a reduction in HTTP calls that are made to the production pages to retrieve the data.