### PR TITLE
Replace requests_async with httpx library

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -437,7 +437,7 @@ class EnvoyReader():
         print("seven_days_consumption:  {}".format(results[5]))
         print("lifetime_production:     {}".format(results[6]))
         print("lifetime_consumption:    {}".format(results[7]))
-        print("inverters_production:   {}".format(results[8]))
+        print("inverters_production:    {}".format(results[8]))
 
 
 if __name__ == "__main__":

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -372,6 +372,11 @@ class EnvoyReader():
         """Hit a different Envoy endpoint and get the production values for
          individual inverters"""
 
+        if self.endpoint_type == "":
+            await self.detect_model()
+        if self.endpoint_type == "P0":
+            return "Inverter data not available for your Envoy device."
+            
         """If a password was not given as an argument when instantiating
         the EnvoyReader object than use the last six numbers of the serial
         number as the password.  Otherwise use the password argument value."""

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -4,7 +4,6 @@ import time
 
 import re
 import httpx
-import h11
 
 """Module to read production and consumption values from an Enphase Envoy on
  the local network"""

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -117,7 +117,7 @@ class EnvoyReader():
         if self.endpoint_type == "P0":
             async with httpx.AsyncClient() as client:
                 response = await client.get(
-                    ENDPOINT_URL_PRODUCTION, timeout=30, allow_redirects=False)
+                    ENDPOINT_URL_PRODUCTION.format(self.host), timeout=30, allow_redirects=False)
             return response.text       # these Envoys have .html
 
     def create_connect_errormessage(self):
@@ -371,7 +371,7 @@ class EnvoyReader():
     async def inverters_production(self):
         """Hit a different Envoy endpoint and get the production values for
          individual inverters"""
-         
+
         """If a password was not given as an argument when instantiating
         the EnvoyReader object than use the last six numbers of the serial
         number as the password.  Otherwise use the password argument value."""

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@ setuptools.setup(
     url="https://github.com/jesserizzo/envoy_reader",
     packages=setuptools.find_packages(),
     install_requires=[
-        "httpx >= 0.12.1",
-        "requests_async >= 0.6.0"
+        "httpx >= 0.12.1"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.17.1",
+    version="0.17.2",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
Removed references to `requests_async` library and replaced HTTP requests with the `httpx` library

Fixes #48 

