### PR TITLE
Create hotfix to fix Production data issue with <3.9 firmware

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -387,6 +387,11 @@ class EnvoyReader():
     async def inverters_production(self):
         """Hit a different Envoy endpoint and get the production values for
          individual inverters"""
+        
+        if self.endpoint_type == "":
+            await self.detect_model()
+        if self.endpoint_type == "P0":
+            return "Inverter data not available for your Envoy device."
          
         """If a password was not given as an argument when instantiating
         the EnvoyReader object than use the last six numbers of the serial

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -112,7 +112,7 @@ class EnvoyReader():
         """Leaving here to get data for older Envoys"""
         if self.endpoint_type == "P0":
             response = await requests.get(
-                ENDPOINT_URL_PRODUCTION, timeout=30, allow_redirects=False)
+                ENDPOINT_URL_PRODUCTION.format(self.host), timeout=30, allow_redirects=False)
             return response.text       # these Envoys have .html
 
     def create_connect_errormessage(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.17.0",
+    version="0.17.0a",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
During testing it was found that a bug was introduced in 0.17.0 that broke getting Production data for Envoys running <3.9 firmware.

This PR backports the fix from 0.17.2 release, and also includes a change in 0.17.2 that does not gather Inverter data for Envoys running <3.9 as they do not support this.