### PR TITLE
Change version number for hotfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.17.0c",
+    version="0.17.3",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
I guess the letter at the end of the version string indicates a Pre-Release, so as to avoid confusion the hotfix will be bumped to 0.17.3. And in another PR the `master` with the latest changes (since the hotfix was selective backports and some changes did occur from 0.17.1 to 10.17.2 which are currently not needed) will be bumped to 0.18.0