### PR TITLE
Let I/O occur only when calling getData()

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -164,7 +164,7 @@ class EnvoyReader():
                     production = raw_json["wattsNow"]
                 else:
                     if self.endpoint_type == "P0":
-                        text = self.endpoint_production_results.text()
+                        text = self.endpoint_production_results.text
                         match = re.search(
                             PRODUCTION_REGEX, text, re.MULTILINE)
                         if match:
@@ -218,7 +218,7 @@ class EnvoyReader():
                     daily_production = raw_json["wattHoursToday"]
                 else:
                     if self.endpoint_type == "P0":
-                        text = self.endpoint_production_results.text()
+                        text = self.endpoint_production_results.text
                         match = re.search(
                             DAY_PRODUCTION_REGEX, text, re.MULTILINE)
                         if match:
@@ -274,7 +274,7 @@ class EnvoyReader():
                     seven_days_production = raw_json["wattHoursSevenDays"]
                 else:
                     if self.endpoint_type == "P0":
-                        text = self.endpoint_production_results.text()
+                        text = self.endpoint_production_results.text
                         match = re.search(
                             WEEK_PRODUCTION_REGEX, text, re.MULTILINE)
                         if match:
@@ -327,7 +327,7 @@ class EnvoyReader():
                     lifetime_production = raw_json["wattHoursLifetime"]
                 else:
                     if self.endpoint_type == "P0":
-                        text = self.endpoint_production_results.text()
+                        text = self.endpoint_production_results.text
                         match = re.search(
                             LIFE_PRODUCTION_REGEX, text, re.MULTILINE)
                         if match:

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -44,7 +44,6 @@ class EnvoyReader():
         self.endpoint_production_inverters = ""
         self.endpoint_production_results = ""
         self.isMeteringEnabled = False
-        self.isDataRetrieved = False
 
     def hasProductionAndConsumption(self, json):
         """Check if json has keys for both production and consumption"""
@@ -96,8 +95,6 @@ class EnvoyReader():
                 await response.close()
             except httpx.HTTPError:
                 response.raise_for_status()
-
-        self.isDataRetrieved = True
 
     async def detect_model(self):
         """Method to determine if the Envoy supports consumption values or


### PR DESCRIPTION
Making this change as Home Assistant does not want I/O to occur when updating entities.

This change makes it so where the getData() method will retrieve the data, and the other methods will only retrieve what is stored in variables.

Changes that I made at a high-level:
- HTTP requests to Envoys with firmware <3.9 was moved to `getData()`. Other firmwares the HTTP requests (except for Inverter data gathering) was already moved to `getData()`
- Move Inverter gathering to `getData()`
- To support gathering Inverter data I added an optional parameter for the EnvoyReader constructor. So that if Home Assistant config does not have `inverters` then this can be skipped.
- Removed `detect_model()` methods from individual methods and runs only from `getData()`
- Removed `isDataRetrieved` boolean, as this is not used