### PR TITLE
Add retries when gathering Inverter data

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -57,50 +57,48 @@ class EnvoyReader():
             return False
 
     async def getData(self):
+        try:
+            async with httpx.AsyncClient() as client:
+                self.endpoint_production_json_results = await client.get(
+                    ENDPOINT_URL_PRODUCTION_JSON.format(self.host), timeout=30, allow_redirects=False)
+                self.endpoint_production_v1_results = await client.get(
+                    ENDPOINT_URL_PRODUCTION_V1.format(self.host), timeout=30, allow_redirects=False)
+                self.endpoint_production_results = await client.get(
+                    ENDPOINT_URL_PRODUCTION.format(self.host), timeout=30, allow_redirects=False)
+        except httpx.HTTPError:
+            pass
         
-            
-                try:
-                    async with httpx.AsyncClient() as client:
-                        self.endpoint_production_json_results = await client.get(
-                            ENDPOINT_URL_PRODUCTION_JSON.format(self.host), timeout=30, allow_redirects=False)
-                        self.endpoint_production_v1_results = await client.get(
-                            ENDPOINT_URL_PRODUCTION_V1.format(self.host), timeout=30, allow_redirects=False)
-                        self.endpoint_production_results = await client.get(
-                            ENDPOINT_URL_PRODUCTION.format(self.host), timeout=30, allow_redirects=False)
-                except httpx.HTTPError:
-                    pass
-                
-                await self.detect_model()
-                
-                if(self.get_inverters):
-                    for i in range(0,3):
-                        while True:
-                            """If a password was not given as an argument when instantiating
-                            the EnvoyReader object than use the last six numbers of the serial
-                            number as the password.  Otherwise use the password argument value."""
-                            if self.password == "":
-                                if self.serial_number_last_six == "":
-                                    try:
-                                        await self.get_serial_number()
-                                    except httpx.HTTPError:
-                                        raise
-                                    self.password = self.serial_number_last_six
+        await self.detect_model()
+        
+        if(self.get_inverters):
+            for i in range(0,3):
+                while True:
+                    """If a password was not given as an argument when instantiating
+                    the EnvoyReader object than use the last six numbers of the serial
+                    number as the password.  Otherwise use the password argument value."""
+                    if self.password == "":
+                        if self.serial_number_last_six == "":
                             try:
-                                async with httpx.AsyncClient() as client:
-                                    response = await client.get(ENDPOINT_URL_PRODUCTION_INVERTERS.format(self.host),
-                                        timeout=30, auth=httpx.DigestAuth(self.username, self.password))
-                                if response is not None and response.status_code != 401:                                    
-                                    self.endpoint_production_inverters = response
-                                else:
-                                    response.raise_for_status()
-                            except (httpcore.RemoteProtocolError, httpx.RemoteProtocolError) as err:
-                                continue
+                                await self.get_serial_number()
                             except httpx.HTTPError:
-                                response.raise_for_status()
-                            break
-                        break
-                if(i == 2):
-                    raise httpx.RemoteProtocolError(message='Malformed request. Failed after 3 retries.', request=None)
+                                raise
+                            self.password = self.serial_number_last_six
+                    try:
+                        async with httpx.AsyncClient() as client:
+                            response = await client.get(ENDPOINT_URL_PRODUCTION_INVERTERS.format(self.host),
+                                timeout=30, auth=httpx.DigestAuth(self.username, self.password))
+                        if response is not None and response.status_code != 401:                                    
+                            self.endpoint_production_inverters = response
+                        else:
+                            response.raise_for_status()
+                    except (httpcore.RemoteProtocolError, httpx.RemoteProtocolError) as err:
+                        continue
+                    except httpx.HTTPError:
+                        response.raise_for_status()
+                    break
+                break
+        if(i == 2):
+            raise httpx.RemoteProtocolError(message='Malformed request. Failed after 3 retries.', request=None)
 
     async def detect_model(self):
         """Method to determine if the Envoy supports consumption values or

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -393,7 +393,7 @@ class EnvoyReader():
         print("Reading...")
         loop = asyncio.get_event_loop()
         dataResults = loop.run_until_complete(asyncio.gather(
-            self.getData(), return_exceptions=False
+            self.getData(), return_exceptions=True
         ))
 
         loop = asyncio.get_event_loop()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.18.1",
+    version="0.18.2",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
It seems after moving from [requests-async](https://github.com/encode/requests-async) to the [httpx](https://www.python-httpx.org/) library, gathering inverter data sometimes fails.

The [httpx documentation](https://www.python-httpx.org/exceptions/) says `The protocol was violated by the server.` While I've seen a [reference](https://github.com/home-assistant/core/issues/43384) to this occurring when the endpoint is overwelmed.  In my case, I don't think it is the latter, as I was not seeing this issue when using the `requests-async` library.

In any case, I have added a retry mechanism when getting inverter data. If after 3 retries we still get the same `httpx.RemoteProtocolError`, than the library will raise the exception. When using the library in Home Assistant the retry will hopefully minimize the values sometimes bouncing from a value to 0/None/Unavaiable back to a value. On my Envoy running firmware D3.15.7, the Protocol error does not occur on the second retry.