### PR TITLE
Return None for Inverter data for Envoy with <3.9 firmware

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -374,7 +374,7 @@ class EnvoyReader():
 
         """Only return data if Envoy supports retrieving Inverter data"""
         if self.endpoint_type == "P0":
-            return "Inverter data not available for your Envoy device."
+            return None
 
         response_dict = {}
         try:
@@ -416,6 +416,8 @@ class EnvoyReader():
         print("lifetime_consumption:    {}".format(results[7]))
         if "401" in str(dataResults):
             print("inverters_production:    Unable to retrieve inverter data - Authentication failure")
+        elif results[8] is None:
+            print("inverters_production:    Inverter data not available for your Envoy device.")
         else:
             print("inverters_production:    {}".format(results[8]))
 

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -97,8 +97,8 @@ class EnvoyReader():
                         response.raise_for_status()
                     break
                 break
-        if(i == 2):
-            raise httpx.RemoteProtocolError(message='Malformed request. Failed after 3 retries.', request=None)
+            if(i == 2):
+                raise httpx.RemoteProtocolError(message='Malformed request. Failed after 3 retries.', request=None)
 
     async def detect_model(self):
         """Method to determine if the Envoy supports consumption values or

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.18.2",
+    version="0.18.3",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
Fix #60 

Returning `None` rather than a string when retrieving inverter data for an Envoy that does not support inverter data (<3.9 firmware)