### PR TITLE
Update envoy_reader.py getData()

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -56,7 +56,8 @@ class EnvoyReader():
         else:
             return False
 
-    async def getData(self):
+    async def getData(self, getInverters=True):
+        """Default to getting inverter data each read request"""
         try:
             async with httpx.AsyncClient() as client:
                 self.endpoint_production_json_results = await client.get(
@@ -70,7 +71,7 @@ class EnvoyReader():
         
         await self.detect_model()
         
-        if(self.get_inverters):
+        if(self.get_inverters and getInverters):
             for i in range(0,3):
                 while True:
                     """If a password was not given as an argument when instantiating

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -95,7 +95,7 @@ class EnvoyReader():
                     except (httpcore.RemoteProtocolError, httpx.RemoteProtocolError) as err:
                         continue
                     except httpx.HTTPError:
-                        response.raise_for_status()
+                        raise
                     break
                 break
             if(i == 2):


### PR DESCRIPTION
Update getData() to add optional input parameter to not read inverters.
Inverters only update every 5 or 15 mins, depending on Envoy-S configuration, whereas production data updates every minute. Also, requesting inverter data at too short an interval can cause the Envoy to start lagging and eventually timeout. See https://thecomputerperson.wordpress.com/2016/08/03/enphase-envoy-s-data-scraping/#comment-1565 for more details.