### PR TITLE
 Update envoy_reader.py getData()

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -56,7 +56,8 @@ class EnvoyReader():
         else:
             return False
 
-    async def getData(self):
+    async def getData(self, getInverters=True):
+        """Default to getting inverter data each read request"""
         try:
             async with httpx.AsyncClient() as client:
                 self.endpoint_production_json_results = await client.get(
@@ -70,7 +71,7 @@ class EnvoyReader():
         
         await self.detect_model()
         
-        if(self.get_inverters):
+        if(self.get_inverters and getInverters):
             for i in range(0,3):
                 while True:
                     """If a password was not given as an argument when instantiating

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -95,7 +95,7 @@ class EnvoyReader():
                     except (httpcore.RemoteProtocolError, httpx.RemoteProtocolError) as err:
                         continue
                     except httpx.HTTPError:
-                        response.raise_for_status()
+                        raise
                     break
                 break
             if(i == 2):

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -71,30 +71,34 @@ class EnvoyReader():
         await self.detect_model()
         
         if(self.get_inverters):
-            """If a password was not given as an argument when instantiating
-            the EnvoyReader object than use the last six numbers of the serial
-            number as the password.  Otherwise use the password argument value."""
-            if self.password == "":
-                if self.serial_number_last_six == "":
+            for i in range(0,3):
+                while True:
+                    """If a password was not given as an argument when instantiating
+                    the EnvoyReader object than use the last six numbers of the serial
+                    number as the password.  Otherwise use the password argument value."""
+                    if self.password == "":
+                        if self.serial_number_last_six == "":
+                            try:
+                                await self.get_serial_number()
+                            except httpx.HTTPError:
+                                raise
+                            self.password = self.serial_number_last_six
                     try:
-                        await self.get_serial_number()
+                        async with httpx.AsyncClient() as client:
+                            response = await client.get(ENDPOINT_URL_PRODUCTION_INVERTERS.format(self.host),
+                                timeout=30, auth=httpx.DigestAuth(self.username, self.password))
+                        if response is not None and response.status_code != 401:                                    
+                            self.endpoint_production_inverters = response
+                        else:
+                            response.raise_for_status()
+                    except (httpcore.RemoteProtocolError, httpx.RemoteProtocolError) as err:
+                        continue
                     except httpx.HTTPError:
-                        raise
-                    self.password = self.serial_number_last_six
-            try:
-                async with httpx.AsyncClient() as client:
-                    response = await client.get(ENDPOINT_URL_PRODUCTION_INVERTERS.format(self.host),
-                        timeout=30, auth=httpx.DigestAuth(self.username, self.password))
-                if response is not None and response.status_code != 401:                                    
-                    self.endpoint_production_inverters = response
-                else:
-                    response.raise_for_status()
-            except (httpx.RemoteProtocolError):
-                raise
-            except (httpcore.RemoteProtocolError, httpx.RemoteProtocolError):
-                await response.close()
-            except httpx.HTTPError:
-                response.raise_for_status()
+                        response.raise_for_status()
+                    break
+                break
+        if(i == 2):
+            raise httpx.RemoteProtocolError(message='Malformed request. Failed after 3 retries.', request=None)
 
     async def detect_model(self):
         """Method to determine if the Envoy supports consumption values or

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -97,8 +97,8 @@ class EnvoyReader():
                         response.raise_for_status()
                     break
                 break
-        if(i == 2):
-            raise httpx.RemoteProtocolError(message='Malformed request. Failed after 3 retries.', request=None)
+            if(i == 2):
+                raise httpx.RemoteProtocolError(message='Malformed request. Failed after 3 retries.', request=None)
 
     async def detect_model(self):
         """Method to determine if the Envoy supports consumption values or
@@ -374,7 +374,7 @@ class EnvoyReader():
 
         """Only return data if Envoy supports retrieving Inverter data"""
         if self.endpoint_type == "P0":
-            return "Inverter data not available for your Envoy device."
+            return None
 
         response_dict = {}
         try:
@@ -416,6 +416,8 @@ class EnvoyReader():
         print("lifetime_consumption:    {}".format(results[7]))
         if "401" in str(dataResults):
             print("inverters_production:    Unable to retrieve inverter data - Authentication failure")
+        elif results[8] is None:
+            print("inverters_production:    Inverter data not available for your Envoy device.")
         else:
             print("inverters_production:    {}".format(results[8]))
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.18.1",
+    version="0.18.2",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.18.2",
+    version="0.18.3",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
Update getData() to add optional input parameter to not read inverters.
Inverters only update every 5 or 15 mins, depending on Envoy-S configuration, whereas production data updates every minute. Also, requesting inverter data at too short an interval can cause the Envoy to start lagging and eventually timeout. See [https://thecomputerperson.wordpress.com/2016/08/03/enphase-envoy-s-data-scraping/#comment-1565](https://thecomputerperson.wordpress.com/2016/08/03/enphase-envoy-s-data-scraping/#comment-1565) for more details.
