### PR TITLE
Update envoy_reader.py getData()

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -126,7 +126,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                     raise
 
     async def getData(self, getInverters=True):  # pylint: disable=invalid-name
-        """Fetch data from the endpoint and if inverters selected default to fetching inverter data each read request."""
+        """Fetch data from the endpoint and if inverters selected default to fetching inverter data."""
         if not self.endpoint_type:
             await self.detect_model()
         else:

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -125,14 +125,14 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 if attempt == 2:
                     raise
 
-    async def getData(self):  # pylint: disable=invalid-name
-        """Fetch data from the endpoint."""
+    async def getData(self, getInverters=True):  # pylint: disable=invalid-name
+        """Fetch data from the endpoint and if inverters selected default to fetching inverter data each read request."""
         if not self.endpoint_type:
             await self.detect_model()
         else:
             await self._update()
 
-        if not self.get_inverters:
+        if not self.get_inverters or not getInverters:
             return
 
         inverters_url = ENDPOINT_URL_PRODUCTION_INVERTERS.format(self.host)


### PR DESCRIPTION
_feature/optional-fetch-inverters_
Update getData() to add optional input parameter to not read inverters.
Inverters only update every 5 or 15 mins, depending on Envoy-S configuration, whereas production data updates every minute.  Also, requesting inverter data at too short an interval can cause the Envoy to start lagging and eventually timeout.  See [https://thecomputerperson.wordpress.com/2016/08/03/enphase-envoy-s-data-scraping/#comment-1565](https://thecomputerperson.wordpress.com/2016/08/03/enphase-envoy-s-data-scraping/#comment-1565) for more details.
