### PR TITLE
Add Battery storage data

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -489,7 +489,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 self.lifetime_consumption(),
                 self.inverters_production(),
                 self.battery_storage(),
-                return_exceptions=False,
+                return_exceptions=True,
             )
         )
 

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -54,7 +54,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
     message_battery_not_available = (
         "Battery storage data not available for your Envoy device."
     )
-    
+
     message_consumption_not_available = (
         "Consumption data not available for your Envoy device."
     )

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -443,6 +443,25 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
 
         return response_dict
 
+    async def battery_status(self):
+        if self.endpoint_type == ENVOY_MODEL_LEGACY:
+            return None
+
+        response_dict = {}
+        try:
+            raw_json = self.endpoint_production_json_results.json()
+            response_dict["type"] = raw_json["storage"][0]["type"]
+            response_dict["activeCount"] = raw_json["storage"][0]["activeCount"]
+            response_dict["readingTime"] = raw_json["storage"][0]["readingTime"]
+            response_dict["wNow"] = raw_json["storage"][0]["wNow"]
+            response_dict["whNow"] = raw_json["storage"][0]["whNow"]
+            response_dict["state"] = raw_json["storage"][0]["state"]
+        except (JSONDecodeError, KeyError, IndexError, TypeError, AttributeError):
+            return None
+
+        print(response_dict)
+        return response_dict
+
     def run_in_console(self):
         """If running this module directly, print all the values in the console."""
         print("Reading...")
@@ -463,7 +482,8 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 self.lifetime_production(),
                 self.lifetime_consumption(),
                 self.inverters_production(),
-                return_exceptions=True,
+                self.battery_status(),
+                return_exceptions=False,
             )
         )
 
@@ -485,6 +505,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             )
         else:
             print("inverters_production:    {}".format(results[8]))
+        print("battery:                 {}".format(results[9]))
 
 
 if __name__ == "__main__":

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -447,7 +447,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
 
         return response_dict
 
-    async def battery_status(self):
+    async def battery_storage(self):
         """Return battery data from Envoys that support and have batteries installed"""
         if (
             self.endpoint_type == ENVOY_MODEL_LEGACY
@@ -488,7 +488,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 self.lifetime_production(),
                 self.lifetime_consumption(),
                 self.inverters_production(),
-                self.battery_status(),
+                self.battery_storage(),
                 return_exceptions=False,
             )
         )
@@ -511,7 +511,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             )
         else:
             print("inverters_production:    {}".format(results[8]))
-        print("battery:                 {}".format(results[9]))
+        print("battery_storage:         {}".format(results[9]))
 
 
 if __name__ == "__main__":

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -448,7 +448,10 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         return response_dict
 
     async def battery_status(self):
-        if self.endpoint_type == ENVOY_MODEL_LEGACY or self.endpoint_type == ENVOY_MODEL_C:
+        if (
+            self.endpoint_type == ENVOY_MODEL_LEGACY
+            or self.endpoint_type == ENVOY_MODEL_C
+        ):
             return self.message_battery_not_available
 
         response_dict = {}

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -448,6 +448,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         return response_dict
 
     async def battery_status(self):
+        """Return battery data from Envoys that support and have batteries installed"""
         if (
             self.endpoint_type == ENVOY_MODEL_LEGACY
             or self.endpoint_type == ENVOY_MODEL_C
@@ -459,6 +460,9 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         except (JSONDecodeError):
             return None
 
+        """For Envoys that support batteries but do not have them installed the"""
+        """percentFull will not be available in the JSON results. The API will"""
+        """only return battery data if batteries are installed."""
         if "percentFull" not in raw_json["storage"][0].keys():
             return self.message_battery_not_available
 

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -459,7 +459,6 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         except (JSONDecodeError, KeyError, IndexError, TypeError, AttributeError):
             return None
 
-        print(response_dict)
         return response_dict
 
     def run_in_console(self):
@@ -483,7 +482,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 self.lifetime_consumption(),
                 self.inverters_production(),
                 self.battery_status(),
-                return_exceptions=False,
+                return_exceptions=True,
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extra_requirements = {
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.18.5",
+    version="0.19.0",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
Adding Battery storage data that is coming from ```/production.json```

```
"storage": [{"type": "acb","activeCount": 4,"readingTime": 1595203104,"wNow": -178,"whNow": 285,"state": "charging","percentFull": 6}
```

Battery storage data will only be returned when the battery is installed in the Envoy system. To determine if the battery is installed we check for the presence of the ```percentFull``` attribute, as in the above example.

If a battery is not present the ```/production.json``` page will return:
```
"storage":[{"type":"acb","activeCount":0,"readingTime":0,"wNow":0,"whNow":0,"state":"idle"}]}
```
In which case the API will return a message saying the battery storage is not available.

**Pull request recommendations:**
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Fixes #36
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
