### PR TITLE
Add Enpower Smart Switch status

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -491,7 +491,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             return None
 
         if "enpower" not in raw_json.keys():
-            return self.message_battery_not_available
+            return self.message_enpower_not_available
         
         return raw_json["enpower"]
 

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -486,7 +486,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
             return self.message_enpower_not_available
 
         try:
-            raw_json = self.endpoint_production_json_results.json()
+            raw_json = self.endpoint_home_json_results.json()
         except (JSONDecodeError):
             return None
 


### PR DESCRIPTION
Adding the status of the Enpower Smart Switch will let the user know if their system is attached or detached from the grid. This is only supported for systems that have the Enpower Smart Switch installed.

Example output when the device is installed:
```
...
enpower_status:          {'connected': True, 'grid_status': 'closed'}
```

Example output when the device is not installed or running the API against an Envoy that does not support it:
```
...
enpower_status:          Enpower Smart Switch status is not available for your Envoy device.
```

**Pull request recommendations:**
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: Partially Issue #72 
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
