### PR TITLE
Update setup.py/exclude 'tests'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/jesserizzo/envoy_reader",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["tests','tests.*"]),
     install_requires=requirements,
     setup_requires=setup_requirements,
     test_suite="tests",


### PR DESCRIPTION
otherwise it tries to install a package called 'tests' at top level:

```
>>> Emerging (1 of 1) dev-python/envoy-reader-0.18.4::HomeAssistantRepository
>>> Failed to emerge dev-python/envoy-reader-0.18.4, Log file:
>>>  '/var/tmp/portage/dev-python/envoy-reader-0.18.4/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.53, 0.49, 0.46
 * Package:    dev-python/envoy-reader-0.18.4
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   jesse.rizzo@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking envoy-reader-0.18.4.tar.gz to /var/tmp/portage/dev-python/envoy-reader-0.18.4/work
>>> Source unpacked in /var/tmp/portage/dev-python/envoy-reader-0.18.4/work
>>> Preparing source in /var/tmp/portage/dev-python/envoy-reader-0.18.4/work/envoy_reader-0.18.4 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/envoy-reader-0.18.4/work/envoy_reader-0.18.4 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/envoy-reader-0.18.4/work/envoy_reader-0.18.4 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
python3.8 setup.py build -j 10
running build
running build_py
...
running install_egg_info
running egg_info
writing envoy_reader.egg-info/PKG-INFO
writing dependency_links to envoy_reader.egg-info/dependency_links.txt
writing requirements to envoy_reader.egg-info/requires.txt
writing top-level names to envoy_reader.egg-info/top_level.txt
reading manifest file 'envoy_reader.egg-info/SOURCES.txt'
writing manifest file 'envoy_reader.egg-info/SOURCES.txt'
Copying envoy_reader.egg-info to /var/tmp/portage/dev-python/envoy-reader-0.18.4/image/_python3.8/usr/lib/python3.8/site-packages/envoy_reader-0.18.4-py3.8.egg-info
running install_scripts
/usr/lib/python3.8/site-packages/setuptools/dist.py:634: UserWarning: Usage of dash-separated 'max-line-length' will not be supported in future versions. Please use the underscore name 'max_line_length' instead
  warnings.warn(
 * ERROR: dev-python/envoy-reader-0.18.4::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
```

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
