### PR TITLE
Use library to generate and consume password

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -222,7 +222,6 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                 self.password = self.serial_number_last_six = full_serial[-6:]
             else:
                 self.password = gen_passwd
-                
 
     async def get_full_serial_number(self):
         """Method to get the  Envoy serial number."""

--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -4,6 +4,7 @@ import logging
 import re
 import time
 from json.decoder import JSONDecodeError
+from envoy_utils.envoy_utils import EnvoyUtils
 
 import httpx
 
@@ -163,7 +164,6 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         # number as the password.  Otherwise use the password argument value.
         if self.password == "" and not self.serial_number_last_six:
             await self.get_serial_number()
-            self.password = self.serial_number_last_six
 
         try:
             await self._update_from_pc_endpoint()
@@ -217,7 +217,12 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         """Method to get last six digits of Envoy serial number for auth"""
         full_serial = await self.get_full_serial_number()
         if full_serial:
-            self.serial_number_last_six = full_serial[-6:]
+            gen_passwd = EnvoyUtils.get_password(full_serial, self.username)
+            if self.username == "envoy" or self.username != "installer":
+                self.password = self.serial_number_last_six = full_serial[-6:]
+            else:
+                self.password = gen_passwd
+                
 
     async def get_full_serial_number(self):
         """Method to get the  Envoy serial number."""

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ dev_requirements = [
     "wheel>=0.34.2",
 ]
 
-requirements = ["httpx>=0.12.1"]
+requirements = ["httpx>=0.12.1", "envoy_utils>=0.0.1"]
 
 extra_requirements = {
     "setup": setup_requirements,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extra_requirements = {
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.19.0",
+    version="0.20.0",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request: Generate password
- [x] Link to any relevant issue in the PR description: Fixes #79 
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

The `EnvoyUtils.get_password()` will generate a password for the `installer` account. Does not create a password for other accounts, but I have left it in the code that the `get_password()` will be run if the account is `!= envoy` just in case there are other accounts that this will work for.

Thanks for contributing!
