### PR TITLE
Support for later httpx releases

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -115,7 +115,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         """Update a property from an endpoint."""
         formatted_url = url.format(self.host)
         response = await self._async_fetch_with_retry(
-            formatted_url, allow_redirects=False
+            formatted_url, follow_redirects=False
         )
         setattr(self, attr, response)
         _LOGGER.debug("Fetched from %s: %s: %s", formatted_url, response, response.text)
@@ -227,7 +227,7 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
         """Method to get the  Envoy serial number."""
         response = await self._async_fetch_with_retry(
             "http://{}/info.xml".format(self.host),
-            allow_redirects=True,
+            follow_redirects=True,
         )
         if not response.text:
             return None

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ dev_requirements = [
     "wheel>=0.34.2",
 ]
 
-requirements = ["httpx>=0.12.1", "envoy_utils>=0.0.1"]
+requirements = ["httpx>=0.20", "envoy_utils>=0.0.1"]
 
 extra_requirements = {
     "setup": setup_requirements,


### PR DESCRIPTION
WIth [`httpx-0.20.0`](https://github.com/encode/httpx/blob/master/CHANGELOG.md#0200-13th-october-2021) the signature changed.

A lot of distributions and Home Assistant will support `httpx-0.20.0`.