### PR TITLE
Bump API version to 0.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests_async >= 0.6.0
-httpx >= 0.12.1
+httpx >= 0.20

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.3
+current_version = 0.20.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ extra_requirements = {
 
 setuptools.setup(
     name="envoy_reader",
-    version="0.20.0",
+    version="0.20.1",
     author="Jesse Rizzo",
     author_email="jesse.rizzo@gmail.com",
     description="A program to read from an Enphase Envoy on the local network",


### PR DESCRIPTION
Bumping API to version 0.20.1

Changes are:
- use httpx >= 0.20
- define the MIT license in setup.py
