### PR TITLE
retry 401s from the envoy

### DIFF
--- a/envoy_reader/envoy_reader.py
+++ b/envoy_reader/envoy_reader.py
@@ -164,6 +164,13 @@ class EnvoyReader:  # pylint: disable=too-many-instance-attributes
                     resp = await client.get(
                         url, headers=self._authorization_header, timeout=30, **kwargs
                     )
+                    if resp.status_code == 401 and attempt < 2:               
+                        _LOGGER.debug(
+                            "Received 401 from Envoy; refreshing token, attempt %s of 2",
+                            attempt+1,
+                            )                               
+                        await self._getEnphaseToken()       
+                        continue  
                     _LOGGER.debug("Fetched from %s: %s: %s", url, resp, resp.text)
                     return resp
             except httpx.TransportError:


### PR DESCRIPTION
Because there can be enough time between when _is_enphase_token_expired()
is called and when the subsequent http request to the envoy happens,
the token freshness check can pass but the envoy will still see an
expired token. This results in a 401 from the envoy, which raises
an exception.

This change looks for these 401s and attempts to refresh the
token twice before giving up.

**Pull request recommendations:**
- [ ] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
